### PR TITLE
feat(media): support alt_text on thread containers + readable alt_text on media

### DIFF
--- a/lib/api/models/fields.dart
+++ b/lib/api/models/fields.dart
@@ -20,6 +20,7 @@ enum MediaFields {
   isReplyOwnedByMe,
   hideStatus,
   replyAudience,
+  altText,
 }
 
 extension MediaFieldsExtension on MediaFields {
@@ -65,6 +66,8 @@ extension MediaFieldsExtension on MediaFields {
         return 'hide_status';
       case MediaFields.replyAudience:
         return 'reply_audience';
+      case MediaFields.altText:
+        return 'alt_text';
       default:
         return 'id';
     }

--- a/lib/api/models/media_post.dart
+++ b/lib/api/models/media_post.dart
@@ -20,6 +20,7 @@ class MediaPost {
   final bool? isReply;
   final bool? isReplyOwnedByMe;
   final String? replyAudience;
+  final String? altText;
 
   MediaPost({
     required this.id,
@@ -41,6 +42,7 @@ class MediaPost {
     this.isReply,
     this.isReplyOwnedByMe,
     this.replyAudience,
+    this.altText,
   });
 
   // Factory constructor to create a MediaPost object from JSON
@@ -65,6 +67,7 @@ class MediaPost {
       isReply: json['is_reply'],
       isReplyOwnedByMe: json['is_reply_owned_by_me'],
       replyAudience: json['reply_audience'],
+      altText: json['alt_text'],
     );
   }
 
@@ -90,6 +93,7 @@ class MediaPost {
       'is_reply': isReply,
       'is_reply_owned_by_me': isReplyOwnedByMe,
       'reply_audience': replyAudience,
+      'alt_text': altText,
     };
   }
 }

--- a/lib/api/threads_media/threads_media.dart
+++ b/lib/api/threads_media/threads_media.dart
@@ -97,6 +97,9 @@ abstract class ThreadsMediaService {
   /// - `text` (optional): The textual content of the thread.
   /// - `imageUrl` (optional): The URL of the image to include in the thread.
   ///   This field is required if the post includes media content.
+  /// - `altText` (optional): The accessibility label / description for the
+  ///   image or video in the post. Only applies to image and video containers
+  ///   (including carousel item containers).
   /// - `inReplyToId` (optional): The ID of the thread that this post is replying to.
   /// - `quotePostId` (optional): The ID of the post being quoted.
   /// - `mediaType` (required): The type of media included in the post (e.g.,
@@ -133,6 +136,7 @@ abstract class ThreadsMediaService {
     String? text,
     String? imageUrl,
     String? videoUrl,
+    String? altText,
     String? inReplyToId,
     String? quotePostId,
     MediaType mediaType,
@@ -532,6 +536,7 @@ class _ThreadsMediaService extends BaseService implements ThreadsMediaService {
       String? text,
       String? imageUrl,
       String? videoUrl,
+      String? altText,
       String? inReplyToId,
       MediaType mediaType = MediaType.textPost,
       String? quotePostId,
@@ -546,6 +551,7 @@ class _ThreadsMediaService extends BaseService implements ThreadsMediaService {
             'text': text,
             'image_url': imageUrl,
             'video_url': videoUrl,
+            'alt_text': altText,
             'quote_post_id': quotePostId,
             'reply_to_id': inReplyToId,
             'is_carousel_item': isCarouselItem,


### PR DESCRIPTION
## Summary
Adds Threads accessibility (alt text) support to the SDK, matching the official Threads API ([Accessibility docs](https://developers.facebook.com/docs/threads/posts/accessibility/)).

- **Write:** `createThreadContainer` gains an optional `altText` param, forwarded as the `alt_text` query param on `POST /threads`. Applies to image/video and carousel item containers.
- **Read:** adds `MediaFields.altText` (`alt_text`) and parses/serializes `alt_text` on `MediaPost`, so retrieved media carry their accessibility description.

## Why
Openvibe needs alt-text parity with Mastodon/Bluesky on Threads. The Threads Graph API supports `alt_text` for both publishing and retrieval; the SDK didn't expose it.

## Commits
- feat(media): support alt_text on thread containers
- feat(media): expose readable alt_text on media objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)